### PR TITLE
[PKG-1486] Upgrade to v11.0.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -44,9 +44,4 @@ SET Parquet_DIR=%ARROW_HOME%\cmake\Parquet
 if errorlevel 1 exit 1
 popd
 
-@rem move the arrow_python.* files to solve issue due to missing $RPATH on win-64
-copy /Y "%SRC_DIR%\python\build\dist\lib\*.lib" "%PREFIX%\Lib\"
-copy /Y "%SRC_DIR%\python\build\dist\bin\*.dll" "%PREFIX%\Library\bin\"
-
 rd /s /q %SP_DIR%\pyarrow\tests
-

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -31,9 +31,4 @@ $PYTHON setup.py \
         install --single-version-externally-managed \
                 --record=record.txt
 
-#cp ${SRC_DIR}/python/build/dist/lib/*${SHLIB_EXT} ${PREFIX}/lib
-cp -r ${SRC_DIR}/python/build/dist/lib/* ${PREFIX}/lib
-cp -r ${SRC_DIR}/python/build/dist/include/* ${PREFIX}/include
-
 rm -r ${SP_DIR}/pyarrow/tests
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,8 @@ build:
     - {{ SP_DIR }}/pyarrow
   missing_dso_whitelist:
     # These can be found in {{ SP_DIR }}, see the tests below
-    - "*/libarrow_python{{ SHLIB_EXT }}"         #[unix]
-    - "*/libarrow_python_flight{{ SHLIB_EXT }}"  #[unix]
+    - "*/libarrow_python{{ SHLIB_EXT }}"         # [unix]
+    - "*/libarrow_python_flight{{ SHLIB_EXT }}"  # [unix]
     - "*/arrow_python.dll"                # [win]
     - "*/arrow_python_flight.dll"         # [win]
 
@@ -74,8 +74,8 @@ test:
     - if exist %SP_DIR%/pyarrow/tests/test_array.py exit 1  # [win]
     - test -f ${SP_DIR}/pyarrow/libarrow_python_flight${SHLIB_EXT}  # [unix]
     - test -f ${SP_DIR}/pyarrow/libarrow_python${SHLIB_EXT}  # [unix]
-    - if not exist %SP_DIR%/pyarrow/libarrow_python_flight%SHLIB_EXT% exit 1 # [win]
-    - if not exist %SP_DIR%/pyarrow/libarrow_python%SHLIB_EXT% exit 1 # [win]
+    - if not exist %SP_DIR%\pyarrow\arrow_python.dll exit 1                   # [win]
+    - if not exist %SP_DIR%\pyarrow\arrow_python_flight.dll exit 1            # [win]
 
 about:
   home: https://github.com/apache/arrow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,15 @@ build:
   number: 0
   # arrow-cpp is not available for s390x, see arrow-cpp-feedstock for details.
   skip: true  # [s390x or py<37]
+  rpaths:
+    - lib/
+    - {{ SP_DIR }}/pyarrow
+  missing_dso_whitelist:
+    # These can be found in {{ SP_DIR }}, see the tests below
+    - "*/libarrow_python{{ SHLIB_EXT }}"         #[unix]
+    - "*/libarrow_python_flight{{ SHLIB_EXT }}"  #[unix]
+    - "*/arrow_python.dll"                # [win]
+    - "*/arrow_python_flight.dll"         # [win]
 
 requirements:
   build:
@@ -63,6 +72,10 @@ test:
   commands:
     - test ! -f ${SP_DIR}/pyarrow/tests/test_array.py       # [unix]
     - if exist %SP_DIR%/pyarrow/tests/test_array.py exit 1  # [win]
+    - test -f ${SP_DIR}/pyarrow/libarrow_python_flight${SHLIB_EXT}  # [unix]
+    - test -f ${SP_DIR}/pyarrow/libarrow_python${SHLIB_EXT}  # [unix]
+    - if not exist %SP_DIR%/pyarrow/libarrow_python_flight%SHLIB_EXT% exit 1 # [win]
+    - if not exist %SP_DIR%/pyarrow/libarrow_python%SHLIB_EXT% exit 1 # [win]
 
 about:
   home: https://github.com/apache/arrow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,8 @@
-{% set version = "10.0.1" %}
+# Note that this feedstock must be paired with bumping the version of
+# `arrow-cpp-feedstock` and the SHA-256 hashes should match between the packages.
+{% set version = "11.0.0" %}
 {% set filename = "apache-arrow-" + version + ".tar.gz" %}
-{% set checksum = "c814e0670112a22c1a6ec03ab420a52ae236a9a42e9e438c3cbd37f37e658fb3" %}
+{% set sha256 = "2dd8f0ea0848a58785628ee3a57675548d509e17213a2f5d72b0d900b43f5430" %}
 
 package:
   name: pyarrow
@@ -9,7 +11,7 @@ package:
 source:
   fn: {{ filename }}
   url: https://dist.apache.org/repos/dist/release/arrow/arrow-{{ version }}/{{ filename }}
-  sha256: {{ checksum }}
+  sha256: {{ sha256 }}
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ filename }}
   url: https://dist.apache.org/repos/dist/release/arrow/arrow-{{ version }}/{{ filename }}
   sha256: {{ sha256 }}
 


### PR DESCRIPTION
- Upgrades to v11.0.0
- Removes copying of build artifacts that no longer appear to be needed. These build directories no longer exist.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
