### PR TITLE
pyarrow 17.0.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/arrow-cpp-feedstock/pr42/7a82b09

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/arrow-cpp-feedstock/pr42/7a82b09
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 # Note that this feedstock must be paired with bumping the version of
 # `arrow-cpp-feedstock` and the SHA-256 hashes should match between the packages.
-{% set version = "16.1.0" %}
+{% set version = "17.0.0" %}
 {% set filename = "apache-arrow-" + version + ".tar.gz" %}
-{% set sha256 = "c9e60c7e87e59383d21b20dc874b17153729ee153264af6d21654b7dff2c60d7" %}
+{% set sha256 = "9d280d8042e7cf526f8c28d170d93bfab65e50f94569f6a790982a878d8d898d" %}
 
 package:
   name: pyarrow


### PR DESCRIPTION
pyarrow 17.0.0

**Destination channel:** defaults

### Links

- [PKG-6290]

### Depends on 

- AnacondaRecipes/arrow-cpp-feedstock#42

### Explanation of changes:

- bump version
- this must depend on the same version of `arrow-cpp` in AnacondaRecipes/arrow-cpp-feedstock#42


[PKG-6290]: https://anaconda.atlassian.net/browse/PKG-6290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ