### PR TITLE
pyarrow 23.0.1 Windows CUDA enablement (PKG-13209)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -24,15 +24,15 @@ SET PYARROW_WITH_GCS=0
 SET PYARROW_GENERATE_COVERAGE=0
 SET PYARROW_BUNDLE_ARROW_CPP=0
 SET PYARROW_BUNDLE_CYTHON_CPP=0
-@rem manually specify the path to the cmake config files
-SET Arrow_DIR=%ARROW_HOME%\cmake\Arrow
-SET ArrowFlight_DIR=%ARROW_HOME%\cmake\ArrowFlight
-SET ArrowDataset_DIR=%ARROW_HOME%\cmake\ArrowDataset
-SET ArrowAcero_DIR=%ARROW_HOME%\cmake\ArrowAcero
-SET Parquet_DIR=%ARROW_HOME%\cmake\Parquet
-SET ArrowSubstrait_DIR=%ARROW_HOME%\cmake\ArrowSubstrait
-SET ArrowCompute_DIR=%ARROW_HOME%\cmake\ArrowCompute
-if "%PYARROW_WITH_CUDA%"=="1" SET ArrowCUDA_DIR=%ARROW_HOME%\cmake\ArrowCUDA
+@rem point to arrow-cpp's cmake config files (conda convention: %LIBRARY_PREFIX%\lib\cmake\<Pkg>)
+SET Arrow_DIR=%ARROW_HOME%\lib\cmake\Arrow
+SET ArrowFlight_DIR=%ARROW_HOME%\lib\cmake\ArrowFlight
+SET ArrowDataset_DIR=%ARROW_HOME%\lib\cmake\ArrowDataset
+SET ArrowAcero_DIR=%ARROW_HOME%\lib\cmake\ArrowAcero
+SET Parquet_DIR=%ARROW_HOME%\lib\cmake\Parquet
+SET ArrowSubstrait_DIR=%ARROW_HOME%\lib\cmake\ArrowSubstrait
+SET ArrowCompute_DIR=%ARROW_HOME%\lib\cmake\ArrowCompute
+if "%PYARROW_WITH_CUDA%"=="1" SET ArrowCUDA_DIR=%ARROW_HOME%\lib\cmake\ArrowCUDA
 
 "%PYTHON%" -m pip install . -vv --no-deps --no-build-isolation
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -24,15 +24,9 @@ SET PYARROW_WITH_GCS=0
 SET PYARROW_GENERATE_COVERAGE=0
 SET PYARROW_BUNDLE_ARROW_CPP=0
 SET PYARROW_BUNDLE_CYTHON_CPP=0
-@rem point to arrow-cpp's cmake config files (conda convention: %LIBRARY_PREFIX%\lib\cmake\<Pkg>)
-SET Arrow_DIR=%ARROW_HOME%\lib\cmake\Arrow
-SET ArrowFlight_DIR=%ARROW_HOME%\lib\cmake\ArrowFlight
-SET ArrowDataset_DIR=%ARROW_HOME%\lib\cmake\ArrowDataset
-SET ArrowAcero_DIR=%ARROW_HOME%\lib\cmake\ArrowAcero
-SET Parquet_DIR=%ARROW_HOME%\lib\cmake\Parquet
-SET ArrowSubstrait_DIR=%ARROW_HOME%\lib\cmake\ArrowSubstrait
-SET ArrowCompute_DIR=%ARROW_HOME%\lib\cmake\ArrowCompute
-if "%PYARROW_WITH_CUDA%"=="1" SET ArrowCUDA_DIR=%ARROW_HOME%\lib\cmake\ArrowCUDA
+@rem CMake's find_package auto-discovers arrow-cpp's config files via ARROW_HOME
+@rem (searches %ARROW_HOME%\lib\cmake\<Pkg>\). No explicit *_DIR overrides needed
+@rem once arrow-cpp installs at the conda convention path — matches Linux build.sh.
 
 "%PYTHON%" -m pip install . -vv --no-deps --no-build-isolation
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -24,10 +24,6 @@ SET PYARROW_WITH_GCS=0
 SET PYARROW_GENERATE_COVERAGE=0
 SET PYARROW_BUNDLE_ARROW_CPP=0
 SET PYARROW_BUNDLE_CYTHON_CPP=0
-@rem CMake's find_package auto-discovers arrow-cpp's config files via ARROW_HOME
-@rem (searches %ARROW_HOME%\lib\cmake\<Pkg>\). No explicit *_DIR overrides needed
-@rem once arrow-cpp installs at the conda convention path — matches Linux build.sh.
-
 "%PYTHON%" -m pip install . -vv --no-deps --no-build-isolation
 
 if errorlevel 1 exit 1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,11 +1,11 @@
 gpu_variant:
   - none
-  - cuda-12                             # [linux]
-  - cuda-13                             # [linux]
+  - cuda-12                             # [win or linux]
+  - cuda-13                             # [win or linux]
 cuda_compiler_version:
   - none
-  - 12.9                                # [linux]
-  - 13.1                                # [linux]
+  - 12.9                                # [win or linux]
+  - 13.1                                # [win or linux]
 
 # No GCC downgrade needed: pyarrow does not compile .cu files.
 # It builds Python bindings that link against arrow-cpp's CUDA library (libarrow_cuda).

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -153,7 +153,7 @@ test:
     - pyarrow._hdfs
   commands:
     - pip check
-    - python -c "import pyarrow.cuda"  # [linux and (gpu_variant or "").startswith("cuda")]
+    - python -c "import pyarrow.cuda"  # [(linux or win) and (gpu_variant or "").startswith("cuda")]
     # Check for pytests in the site-package dir
     - test -f ${SP_DIR}/pyarrow/tests/test_array.py  # [unix]
     - if not exist %SP_DIR%/pyarrow/tests/test_array.py exit 1  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 # `arrow-cpp-feedstock` and the SHA-256 hashes should match between the packages.
 {% set name = "pyarrow" %}
 {% set version = "23.0.1" %}
-{% set build_number = 2 %}
+{% set build_number = 3 %}
 {% set cuda_enabled = (gpu_variant or "").startswith("cuda") %}
 
 package:


### PR DESCRIPTION
pyarrow 23.0.1

**Destination channel:** defaults

### Links

- [PKG-13209](https://anaconda.atlassian.net/browse/PKG-13209)
- [Upstream repository](https://github.com/apache/arrow)
- Relevant dependency PRs:
  - [arrow-cpp #63](https://github.com/AnacondaRecipes/arrow-cpp-feedstock/pull/63) — Windows CUDA enablement + `CMAKE_INSTALL_LIBDIR` layout fix 

### Explanation of changes:

Mirrors arrow-cpp #63 for pyarrow, plus two small cleanups unlocked by arrow-cpp's layout fix.

- **`recipe/conda_build_config.yaml`**: gate `cuda-12` (12.9) and `cuda-13` (13.1) variants to `# [win or linux]` instead of `# [linux]`. Enables Windows CUDA builds for the first time


[PKG-13209]: https://anaconda.atlassian.net/browse/PKG-13209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ