### PR TITLE
rebuild against CUDA 12.9 + 13.0, add __cuda to run

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,7 +5,7 @@ gpu_variant:
 cuda_compiler_version:
   - none
   - 12.9                                # [win or linux]
-  - 13.1                                # [win or linux]
+  - 13.0                                # [win or linux]
 
 # No GCC downgrade needed: pyarrow does not compile .cu files.
 # It builds Python bindings that link against arrow-cpp's CUDA library (libarrow_cuda).

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 # `arrow-cpp-feedstock` and the SHA-256 hashes should match between the packages.
 {% set name = "pyarrow" %}
 {% set version = "23.0.1" %}
-{% set build_number = 3 %}
+{% set build_number = 4 %}
 {% set cuda_enabled = (gpu_variant or "").startswith("cuda") %}
 
 package:
@@ -74,7 +74,11 @@ requirements:
     - cuda-version {{ cuda_compiler_version }}  # [(gpu_variant or "").startswith("cuda")]
   run:
     - python
-    # CUDA runtime dep (__cuda handled automatically by cuda-version via run_constrained)
+    # Gate the CUDA build to GPU hosts. __cuda must be a hard run dep (unbounded):
+    # cuda-version only constrains __cuda via run_constrained, which is not a hard
+    # gate, so the CUDA variant would otherwise resolve on CPU-only machines.
+    # cuda-version handles the version. (Apr-2026 CUDA Variant Packaging decision.)
+    - __cuda                                              # [(gpu_variant or "").startswith("cuda")]
     - {{ pin_compatible('cuda-version', max_pin='x.x') }}  # [(gpu_variant or "").startswith("cuda")]
 
 # ValueError: scipy.sparse does not support dtype float16. The only supported types are: bool_, int8, uint8, int16, uint16, int32, uint32, int64, uint64, longlong, ulonglong, float32, float64, longdouble, complex64, complex128, clongdouble.


### PR DESCRIPTION
> **⚠️ DRAFT — blocked on arrow-cpp.** The graph-submitter fails deterministically:
> `nothing provides __cuda needed by arrow-cpp-23.0.1-cuda130_h2fc0efc_105`.
> The only CUDA-13.0 `arrow-cpp` on pkgs/main (`cuda130_105`, from PKG-14682) has
> `__cuda` as a **hard `run` dep**, so it's uninstallable on the GPU-less graph-submitter
> lambda — and pyarrow host-pins `arrow-cpp cuda130*`. arrow-cpp's recipe intends
> `__cuda` in `run_constrained` only (with a comment about not breaking pyarrow), so the
> built `cuda130_105` has a regression. **Needs arrow-cpp (PKG-14682) rebuilt with
> `__cuda` kept out of `run` (run_constrained only)** before this PR can build. The pyarrow
> changes below are correct and ready once unblocked.

pyarrow - rebuild against CUDA 12.9 + 13.0, add `__cuda` to run

**Destination channel:** defaults

### Links

- [PKG-14686](https://anaconda.atlassian.net/browse/PKG-14686)
- [PKG-13074 (2026Q2 AI & Growth — CUDA coverage epic)](https://anaconda.atlassian.net/browse/PKG-13074)
- [PKG-14682 (arrow-cpp 12.9/13.0 — the dependency this builds against)](https://anaconda.atlassian.net/browse/PKG-14682)
- [Upstream repository](https://github.com/apache/arrow)

### Explanation of changes:

- **CUDA 13.1 → 13.0** (CBC) to match the Q2 CUDA-coverage standard of 12.9 + 13.0 (PKG-13074) and the now-released `arrow-cpp` `cuda130` builds (PKG-14682). pyarrow host-pins `arrow-cpp {{ version }} cuda{{ cuda_compiler_version | replace('.','') }}*`, so the CUDA-13 variant now links `arrow-cpp 23.0.1 cuda130*` (confirmed present on pkgs/main for linux-64, linux-aarch64, win-64). The 12.9 variant is unchanged (links `arrow-cpp 23.0.1 cuda129*`).
- **`__cuda` (unbounded) added to the cuda variant's `run`.** Previously the recipe relied on `cuda-version`'s `run_constrained` `__cuda`, which is *not* a hard gate (it only constrains if `cuda-version` is already being installed) — so the CUDA build could resolve on CPU-only hosts. A hard, unbounded `__cuda` in `run` gates it to GPU hosts; `cuda-version` still handles the version. (Apr-2026 CUDA Variant Packaging decision.)
- **Build number 3 → 4.** CUDA variants get `+100` (→ 104); the new `cuda130_*_104` builds supersede the previously released `cuda131_*_103` within the `cuda-version >=13,<14` range. CPU and `cuda129` variants rebuild identically at the new number.
- **Coverage after this PR:** cpu + CUDA 12.9 + CUDA 13.0 on linux-64, linux-aarch64, and win-64 (cuda gated `[win or linux]`; `linux` covers aarch64). No platform/variant-structure changes — pyarrow already covered all three platforms; this is the 13.0 rebuild + `__cuda` fix.


[PKG-14686]: https://anaconda.atlassian.net/browse/PKG-14686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
